### PR TITLE
Fall back to anonymous token if auth token refresh fails

### DIFF
--- a/chat.ts
+++ b/chat.ts
@@ -53,7 +53,7 @@ export class User {
     }
   }
   async #doRefresh(): Promise<void> {
-    const tokens = await refreshAuthToken(this.deviceId, this.#refreshToken)
+    const tokens = await refreshAuthToken(this.deviceId, this.#refreshToken).catch(() => fetchAnonymousToken(this.deviceId))
     this.#accessToken = tokens.accessToken
     this.#refreshToken = tokens.refreshToken
     if (tokens.expiresAt !== null) {


### PR DESCRIPTION
## Summary
Added error handling to the token refresh flow to gracefully degrade to anonymous authentication when the refresh token request fails.

## Key Changes
- Modified `#doRefresh()` method to catch failures in `refreshAuthToken()` and fall back to `fetchAnonymousToken()` as a recovery mechanism
- This ensures the application can continue operating with anonymous credentials if the standard token refresh fails, improving resilience and user experience

## Implementation Details
- Used `.catch()` promise handler to intercept refresh failures and attempt anonymous token fetch
- The fallback maintains the same token assignment flow, allowing the rest of the refresh logic to proceed normally with either refreshed or anonymous tokens

https://claude.ai/code/session_01KBKiHVh4UVwtzUmS7cz7LW